### PR TITLE
fix: clarify missing fields error message

### DIFF
--- a/app/api/person-id/route.ts
+++ b/app/api/person-id/route.ts
@@ -16,7 +16,7 @@ const norm = (s: string) =>
 
 export async function POST(req: Request) {
   const { name, electorate } = (await req.json()) as { name?: string; electorate?: string };
-  if (!name || !electorate) return new Response("name + electorate required", { status: 400 });
+  if (!name || !electorate) return new Response("name and electorate required", { status: 400 });
 
   const people = await tvfy<TVFYPerson[]>("/people.json");
 


### PR DESCRIPTION
## Summary
- update POST person-id API to return `name and electorate required` when inputs missing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: @typescript-eslint/no-explicit-any)


------
https://chatgpt.com/codex/tasks/task_e_6897407e56988330aa36429a43b6e83d