### PR TITLE
fix: load votes for selected MP

### DIFF
--- a/components/PostcodeTool.tsx
+++ b/components/PostcodeTool.tsx
@@ -53,7 +53,9 @@ export default function PostcodeTool() {
     setLoading(true);
     try {
       const id = Number(rep.person_id);
-      const vv = await fetch(`/api/mp/${id}/votes`);
+      // Fetch recent votes for the selected MP. The API route is `/api/mp/[id]`
+      // so we request that path directly rather than a non-existent `/votes` subpath.
+      const vv = await fetch(`/api/mp/${id}`);
       if (!vv.ok) throw new Error("Could not load votes");
       const votes = (await vv.json()) as VoteRow[];
       setVotes(votes);


### PR DESCRIPTION
## Summary
- fetch MP votes from `/api/mp/[id]` endpoint instead of non-existent `/votes` path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689743ba5f348330a27a9787720c42a1