### PR TITLE
fix: await params in MP API

### DIFF
--- a/app/api/mp/[id]/route.ts
+++ b/app/api/mp/[id]/route.ts
@@ -27,8 +27,11 @@ type VoteResult = {
   vote: string;
 };
 
-export async function GET(_req: Request, { params }: { params: { id: string } }) {
-  const id = params.id;
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
   const today = new Date();
   const start = new Date(today);
   start.setMonth(start.getMonth() - 2); // last ~60 days


### PR DESCRIPTION
## Summary
- await dynamic route params in MP API before using `id`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689746bc017c8330a71a16f811832c32