### PR TITLE
Expand vote lookup window to six months

### DIFF
--- a/app/api/mp/[id]/route.ts
+++ b/app/api/mp/[id]/route.ts
@@ -34,7 +34,7 @@ export async function GET(
   const { id } = await params;
   const today = new Date();
   const start = new Date(today);
-  start.setMonth(start.getMonth() - 2); // last ~60 days
+  start.setMonth(start.getMonth() - 6); // look back six months for more results
   const toISO = (d: Date) => d.toISOString().slice(0, 10);
 
   const divisions = await tvfy<DivisionSummary[]>("/divisions.json", {


### PR DESCRIPTION
## Summary
- expand MP vote lookup to last six months to reduce "No votes" cases

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68974a0aabb88330b8a6052a3d8f7e96