### PR TITLE
Show tvfy API request and response for debugging

### DIFF
--- a/app/api/mp/[id]/route.ts
+++ b/app/api/mp/[id]/route.ts
@@ -37,14 +37,16 @@ export async function GET(
   start.setMonth(start.getMonth() - 6); // look back six months for more results
   const toISO = (d: Date) => d.toISOString().slice(0, 10);
 
+  const debug: { request: string; response: unknown }[] = [];
+
   const divisions = await tvfy<DivisionSummary[]>("/divisions.json", {
     start_date: toISO(start),
     end_date: toISO(today),
-  });
+  }, debug);
 
   const results: VoteResult[] = [];
   for (const d of divisions) {
-    const full = await tvfy<DivisionDetail>(`/divisions/${d.id}.json`);
+    const full = await tvfy<DivisionDetail>(`/divisions/${d.id}.json`, {}, debug);
     // Match the vote for the selected MP using the nested `person.id`
     // field. Previously we looked for a non-existent `person_id` field,
     // so no votes were ever found and the UI always displayed "No votes
@@ -63,5 +65,5 @@ export async function GET(
       });
     }
   }
-  return Response.json(results);
+  return Response.json({ votes: results, debug });
 }

--- a/components/PostcodeTool.tsx
+++ b/components/PostcodeTool.tsx
@@ -24,12 +24,14 @@ export default function PostcodeTool() {
   const [reps, setReps] = useState<OARepresentative[] | null>(null);
   const [selected, setSelected] = useState<OARepresentative | null>(null);
   const [votes, setVotes] = useState<VoteRow[] | null>(null);
+  const [debug, setDebug] = useState<{ request: string; response: unknown }[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   async function lookup() {
     setError(null);
     setVotes(null);
+    setDebug(null);
     setSelected(null);
     setReps(null);
     if (!postcode.trim()) return;
@@ -49,6 +51,7 @@ export default function PostcodeTool() {
   async function choose(rep: OARepresentative) {
     setSelected(rep);
     setVotes(null);
+    setDebug(null);
     setError(null);
     setLoading(true);
     try {
@@ -57,8 +60,9 @@ export default function PostcodeTool() {
       // so we request that path directly rather than a non-existent `/votes` subpath.
       const vv = await fetch(`/api/mp/${id}`);
       if (!vv.ok) throw new Error("Could not load votes");
-      const votes = (await vv.json()) as VoteRow[];
-      setVotes(votes);
+      const data = (await vv.json()) as { votes: VoteRow[]; debug: { request: string; response: unknown }[] };
+      setVotes(data.votes);
+      setDebug(data.debug);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Something went wrong");
     } finally {
@@ -159,6 +163,18 @@ export default function PostcodeTool() {
                   ))}
                 </tbody>
               </table>
+            </div>
+          )}
+
+          {debug && (
+            <div className="mt-6 text-xs break-all">
+              <h3 className="font-medium mb-1">TVFY debug</h3>
+              {debug.map((d, i) => (
+                <div key={i} className="mb-4">
+                  <div>Request: {d.request}</div>
+                  <pre className="bg-gray-100 p-2 overflow-auto">{JSON.stringify(d.response, null, 2)}</pre>
+                </div>
+              ))}
             </div>
           )}
         </div>

--- a/lib/tvfy.ts
+++ b/lib/tvfy.ts
@@ -2,10 +2,20 @@ const TVFY = "https://theyvoteforyou.org.au/api/v1";
 
 type Params = Record<string, string | number | boolean | undefined>;
 
-export async function tvfy<T>(path: string, params: Params = {}) {
+// Optional debug entry describing a TVFY API call
+type DebugEntry = { request: string; response: unknown };
+
+export async function tvfy<T>(
+  path: string,
+  params: Params = {},
+  debug?: DebugEntry[],
+) {
   const qs = new URLSearchParams({ key: process.env.TVFY_API_KEY! });
   for (const [k, v] of Object.entries(params)) if (v !== undefined) qs.set(k, String(v));
-  const res = await fetch(`${TVFY}${path}?${qs}`, { cache: "no-store" });
+  const url = `${TVFY}${path}?${qs}`;
+  const res = await fetch(url, { cache: "no-store" });
+  const json = await res.json();
+  if (debug) debug.push({ request: url, response: json });
   if (!res.ok) throw new Error(`TVFY ${res.status}`);
-  return res.json() as Promise<T>;
+  return json as T;
 }


### PR DESCRIPTION
## Summary
- capture full TVFY API request and response in server route and library helper
- surface TVFY request/response in PostcodeTool for debugging after electorate selection

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68974dcdff208330bcc7bd4269a1e2be