### PR TITLE
feat: add profile dropdown

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,11 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+details > summary {
+  list-style: none;
+}
+
+details > summary::-webkit-details-marker {
+  display: none;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Header from "@/components/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Header />
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import { auth, signIn, signOut } from "@/auth";
+import { auth } from "@/auth";
 import PostcodeTool from "@/components/PostcodeTool";
 
 export default async function Page() {
@@ -7,31 +7,6 @@ export default async function Page() {
   return (
     <main className="min-h-screen bg-gray-50">
       <div className="max-w-4xl mx-auto p-6">
-        <header className="flex items-center justify-between">
-          <h1 className="text-2xl font-semibold">They Vote For You — Postcode Lookup</h1>
-          <div>
-            {session ? (
-              <form
-                action={async () => {
-                  "use server";
-                  await signOut({ redirectTo: "/" });
-                }}
-              >
-                <button className="px-3 py-2 rounded-lg bg-black text-white">Sign out</button>
-              </form>
-            ) : (
-              <form
-                action={async () => {
-                  "use server";
-                  await signIn("github", { redirectTo: "/" });
-                }}
-              >
-                <button className="px-3 py-2 rounded-lg bg-black text-white">Sign in with GitHub</button>
-              </form>
-            )}
-          </div>
-        </header>
-
         <p className="mt-3 text-gray-600">
           Enter a postcode, pick your electorate if needed, and see how your MP
           voted in recent divisions.

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,57 @@
+import { auth, update } from "@/auth";
+import { redirect } from "next/navigation";
+
+export default async function ProfilePage() {
+  const session = await auth();
+  if (!session) {
+    redirect("/");
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="max-w-4xl mx-auto p-6">
+        <h1 className="text-2xl font-semibold">Profile</h1>
+        <form
+          action={async (formData: FormData) => {
+            "use server";
+            const name = formData.get("name") as string;
+            const image = formData.get("image") as string;
+            await update({ user: { name, image } });
+          }}
+          className="mt-6 space-y-4"
+        >
+          <div>
+            <label className="block text-sm font-medium text-gray-700" htmlFor="name">
+              Name
+            </label>
+            <input
+              id="name"
+              name="name"
+              type="text"
+              defaultValue={session.user?.name ?? ""}
+              className="mt-1 block w-full rounded-md border border-gray-300 p-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700" htmlFor="image">
+              Image URL
+            </label>
+            <input
+              id="image"
+              name="image"
+              type="text"
+              defaultValue={session.user?.image ?? ""}
+              className="mt-1 block w-full rounded-md border border-gray-300 p-2"
+            />
+          </div>
+          <button
+            type="submit"
+            className="px-3 py-2 rounded-lg bg-black text-white"
+          >
+            Save
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/auth.ts
+++ b/auth.ts
@@ -1,7 +1,7 @@
 import NextAuth from "next-auth";
 import GitHub from "next-auth/providers/github";
 
-export const { auth, signIn, signOut, handlers } = NextAuth({
+export const { auth, signIn, signOut, unstable_update: update, handlers } = NextAuth({
   providers: [
     GitHub({
       clientId: process.env.GITHUB_ID!,

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import Image from "next/image";
+import { auth, signIn, signOut } from "@/auth";
+
+export default async function Header() {
+  const session = await auth();
+
+  return (
+    <header className="flex items-center justify-between">
+      <Link href="/" className="text-2xl font-semibold">
+        They Vote For You — Postcode Lookup
+      </Link>
+      <div>
+        {session ? (
+          <details className="relative">
+            <summary className="cursor-pointer">
+              {session.user?.image ? (
+                <Image
+                  src={session.user.image}
+                  alt="Profile"
+                  width={32}
+                  height={32}
+                  className="h-8 w-8 rounded-full"
+                />
+              ) : (
+                <div className="h-8 w-8 rounded-full bg-gray-300" />
+              )}
+            </summary>
+            <div className="absolute right-0 mt-2 w-40 rounded-md border bg-white shadow-lg z-10">
+              <Link
+                href="/profile"
+                className="block px-4 py-2 hover:bg-gray-100"
+              >
+                Profile
+              </Link>
+              <form
+                action={async () => {
+                  "use server";
+                  await signOut({ redirectTo: "/" });
+                }}
+              >
+                <button
+                  type="submit"
+                  className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+                >
+                  Sign out
+                </button>
+              </form>
+            </div>
+          </details>
+        ) : (
+          <form
+            action={async () => {
+              "use server";
+              await signIn("github", { redirectTo: "/" });
+            }}
+          >
+            <button className="px-3 py-2 rounded-lg bg-black text-white">
+              Sign in with GitHub
+            </button>
+          </form>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add header with profile image dropdown linking to profile and sign-out
- create profile page allowing user to update name and avatar
- enable session updates and configure remote GitHub avatar images

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fc6e20d108330a74bb11da49b20e4